### PR TITLE
Download Godot builds from GitHub

### DIFF
--- a/godot3/Dockerfile
+++ b/godot3/Dockerfile
@@ -12,6 +12,8 @@ ARG EXPORT_TEMPLATES=all
 FROM debian:stable-slim AS base
 
 ARG GODOT_VERSION=3.5.3
+ARG GODOT_RELEASE_CHANNEL=stable
+ARG GODOT_DOWNLOAD_BASE=https://github.com/godotengine/godot-builds/releases/download
 
 #------------------------------
 # Installs packages to use wget
@@ -26,16 +28,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Downloads Godot
 FROM wget AS godot
 
-RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip
-RUN unzip Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip
-RUN mv Godot_v${GODOT_VERSION}-stable_linux_headless.64 /usr/local/bin/godot
+RUN wget ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux_headless.64.zip
+RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux_headless.64.zip
+RUN mv Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux_headless.64 /usr/local/bin/godot
 
 #--------------------------------
 # Downloads the export templates
 FROM wget AS templates
 
-RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_export_templates.tpz
-RUN unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz
+RUN wget ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
+RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
 
 #------------------------------
 # Clean setup with no templates

--- a/godot4/Dockerfile
+++ b/godot4/Dockerfile
@@ -16,6 +16,8 @@ ARG EXPORT_TEMPLATES=all
 FROM debian:stable-slim AS base
 
 ARG GODOT_VERSION=4.3
+ARG GODOT_RELEASE_CHANNEL=stable
+ARG GODOT_DOWNLOAD_BASE=https://github.com/godotengine/godot-builds/releases/download
 
 #------------------------------
 # Installs packages to use wget
@@ -30,16 +32,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Downloads Godot
 FROM wget AS godot
 
-RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip
-RUN unzip Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip
-RUN mv Godot_v${GODOT_VERSION}-stable_linux.x86_64 /usr/local/bin/godot
+RUN wget ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux.x86_64.zip
+RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux.x86_64.zip
+RUN mv Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux.x86_64 /usr/local/bin/godot
 
 #--------------------------------
 # Downloads the export templates
 FROM wget AS templates
 
-RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_export_templates.tpz
-RUN unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz
+RUN wget ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
+RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
 
 #------------------------------
 # Clean setup with no templates


### PR DESCRIPTION
## Summary
* switch both Dockerfiles to pull artifacts from the official godot-builds GitHub releases so new versions like 3.6 are available
* keep existing file names by adding configurable release channel vars