### PR TITLE
Retry GitHub downloads

### DIFF
--- a/godot3/Dockerfile
+++ b/godot3/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Downloads Godot
 FROM wget AS godot
 
-RUN wget ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux_headless.64.zip
+RUN wget --retry-connrefused --waitretry=5 --tries=20 --timeout=30 \
+    ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux_headless.64.zip
 RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux_headless.64.zip
 RUN mv Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux_headless.64 /usr/local/bin/godot
 
@@ -36,7 +37,8 @@ RUN mv Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux_headless.64 /usr/l
 # Downloads the export templates
 FROM wget AS templates
 
-RUN wget ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
+RUN wget --retry-connrefused --waitretry=5 --tries=20 --timeout=30 \
+    ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
 RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
 
 #------------------------------

--- a/godot4/Dockerfile
+++ b/godot4/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Downloads Godot
 FROM wget AS godot
 
-RUN wget ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux.x86_64.zip
+RUN wget --retry-connrefused --waitretry=5 --tries=20 --timeout=30 \
+    ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux.x86_64.zip
 RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux.x86_64.zip
 RUN mv Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux.x86_64 /usr/local/bin/godot
 
@@ -40,7 +41,8 @@ RUN mv Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_linux.x86_64 /usr/local/
 # Downloads the export templates
 FROM wget AS templates
 
-RUN wget ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
+RUN wget --retry-connrefused --waitretry=5 --tries=20 --timeout=30 \
+    ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
 RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
 
 #------------------------------


### PR DESCRIPTION
## Summary
* add retrying wget invocations for both binary and template downloads so transient GitHub 503s don't fail builds