### PR TITLE
Fix Godot 3 export template dir

### DIFF
--- a/godot3/Dockerfile
+++ b/godot3/Dockerfile
@@ -40,6 +40,13 @@ FROM wget AS templates
 RUN wget --retry-connrefused --waitretry=5 --tries=20 --timeout=30 \
     ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
 RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
+# Fail fast if upstream hasn't published the UWP templates yet.
+RUN if ls templates/uwp_* >/dev/null 2>&1; then \
+      echo "Found UWP templates for ${GODOT_VERSION}"; \
+    else \
+      echo "Missing UWP export templates for ${GODOT_VERSION}. Please verify the release artifacts." >&2; \
+      exit 1; \
+    fi
 
 #------------------------------
 # Clean setup with no templates
@@ -51,7 +58,6 @@ ENV EXPORT_TEMPLATES_DIR="${XDG_DATA_HOME}/godot/templates/${GODOT_VERSION}.stab
 
 RUN mkdir -p /root/.cache
 RUN mkdir -p /root/.config/godot
-RUN mkdir -p "${EXPORT_TEMPLATES_DIR}"
 
 COPY --from=godot /usr/local/bin/godot /usr/local/bin/godot
 

--- a/godot3/Dockerfile
+++ b/godot3/Dockerfile
@@ -47,10 +47,11 @@ RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
 FROM base AS export-none
 
 ENV XDG_DATA_HOME=/usr/local/share
-ENV EXPORT_TEMPLATES_DIR="${XDG_DATA_HOME}/godot/templates/${GODOT_VERSION}/"
+ENV EXPORT_TEMPLATES_DIR="${XDG_DATA_HOME}/godot/templates/${GODOT_VERSION}.stable/"
 
 RUN mkdir -p /root/.cache
 RUN mkdir -p /root/.config/godot
+RUN mkdir -p "${EXPORT_TEMPLATES_DIR}"
 
 COPY --from=godot /usr/local/bin/godot /usr/local/bin/godot
 
@@ -109,8 +110,8 @@ COPY --from=templates templates/uwp_* ${EXPORT_TEMPLATES_DIR}
 # All windows templates (win + uwp)
 FROM export-none AS export-windows
 
-COPY --from=export-win ${EXPORT_TEMPLATES_DIR} ${EXPORT_TEMPLATES_DIR}
 COPY --from=export-uwp ${EXPORT_TEMPLATES_DIR} ${EXPORT_TEMPLATES_DIR}
+COPY --from=export-win ${EXPORT_TEMPLATES_DIR} ${EXPORT_TEMPLATES_DIR}
 
 #------------------------------
 # All desktop templates

--- a/godot3/Dockerfile
+++ b/godot3/Dockerfile
@@ -40,13 +40,6 @@ FROM wget AS templates
 RUN wget --retry-connrefused --waitretry=5 --tries=20 --timeout=30 \
     ${GODOT_DOWNLOAD_BASE}/${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
 RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
-# Fail fast if upstream hasn't published the UWP templates yet.
-RUN if ls templates/uwp_* >/dev/null 2>&1; then \
-      echo "Found UWP templates for ${GODOT_VERSION}"; \
-    else \
-      echo "Missing UWP export templates for ${GODOT_VERSION}. Please verify the release artifacts." >&2; \
-      exit 1; \
-    fi
 
 #------------------------------
 # Clean setup with no templates
@@ -69,48 +62,65 @@ CMD ["--help"]
 FROM export-none AS export-linux
 
 COPY --from=templates templates/linux* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/linux_x11_32_debug" \
+    && test -e "${EXPORT_TEMPLATES_DIR}/linux_x11_32_release" \
+    && test -e "${EXPORT_TEMPLATES_DIR}/linux_x11_64_debug" \
+    && test -e "${EXPORT_TEMPLATES_DIR}/linux_x11_64_release"
 
 #------------------------------
 # Only osx template
 FROM export-none AS export-osx
 
 COPY --from=templates templates/osx* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/osx.zip"
 
 #------------------------------
 # Only win32 template
 FROM export-none AS export-win32
 
 COPY --from=templates templates/windows_32* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/windows_32_debug.exe" \
+    && test -e "${EXPORT_TEMPLATES_DIR}/windows_32_release.exe"
 
 #------------------------------
 # Only win64 template
 FROM export-none AS export-win64
 
 COPY --from=templates templates/windows_64* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/windows_64_debug.exe" \
+    && test -e "${EXPORT_TEMPLATES_DIR}/windows_64_release.exe"
 
 #------------------------------
 # Only win template (win32+win64)
 FROM export-none AS export-win
 
 COPY --from=templates templates/windows_* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/windows_32_release.exe" \
+    && test -e "${EXPORT_TEMPLATES_DIR}/windows_64_release.exe"
 
 #------------------------------
 # Only uwp32 template
 FROM export-none AS export-uwp32
 
 COPY --from=templates templates/uwp_x86* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/uwp_x86_debug.zip" \
+    && test -e "${EXPORT_TEMPLATES_DIR}/uwp_x86_release.zip"
 
 #------------------------------
 # Only uwp64 template
 FROM export-none AS export-uwp64
 
 COPY --from=templates templates/uwp_x64* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/uwp_x64_debug.zip" \
+    && test -e "${EXPORT_TEMPLATES_DIR}/uwp_x64_release.zip"
 
 #------------------------------
 # All uwp templates
 FROM export-none AS export-uwp
 
 COPY --from=templates templates/uwp_* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/uwp_x86_release.zip" \
+    && test -e "${EXPORT_TEMPLATES_DIR}/uwp_x64_release.zip"
 
 #------------------------------
 # All windows templates (win + uwp)
@@ -132,12 +142,15 @@ COPY --from=export-windows ${EXPORT_TEMPLATES_DIR} ${EXPORT_TEMPLATES_DIR}
 FROM export-none AS export-android
 
 COPY --from=templates templates/android* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/android_debug.apk" \
+    && test -e "${EXPORT_TEMPLATES_DIR}/android_release.apk"
 
 #------------------------------
 # All iphone templates
 FROM export-none AS export-iphone
 
 COPY --from=templates templates/iphone* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/iphone.zip"
 
 #------------------------------
 # All mobile templates
@@ -151,6 +164,7 @@ COPY --from=export-iphone ${EXPORT_TEMPLATES_DIR} ${EXPORT_TEMPLATES_DIR}
 FROM export-none AS export-html
 
 COPY --from=templates templates/webassembly* ${EXPORT_TEMPLATES_DIR}
+RUN test -e "${EXPORT_TEMPLATES_DIR}/webassembly_release.zip"
 
 #------------------------------
 # All templates

--- a/godot3/Dockerfile
+++ b/godot3/Dockerfile
@@ -47,7 +47,7 @@ RUN unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE_CHANNEL}_export_templates.tpz
 FROM base AS export-none
 
 ENV XDG_DATA_HOME=/usr/local/share
-ENV EXPORT_TEMPLATES_DIR="${XDG_DATA_HOME}/godot/templates/${GODOT_VERSION}.stable/"
+ENV EXPORT_TEMPLATES_DIR="${XDG_DATA_HOME}/godot/templates/${GODOT_VERSION}/"
 
 RUN mkdir -p /root/.cache
 RUN mkdir -p /root/.config/godot
@@ -109,8 +109,8 @@ COPY --from=templates templates/uwp_* ${EXPORT_TEMPLATES_DIR}
 # All windows templates (win + uwp)
 FROM export-none AS export-windows
 
-COPY --from=export-uwp ${EXPORT_TEMPLATES_DIR} ${EXPORT_TEMPLATES_DIR}
 COPY --from=export-win ${EXPORT_TEMPLATES_DIR} ${EXPORT_TEMPLATES_DIR}
+COPY --from=export-uwp ${EXPORT_TEMPLATES_DIR} ${EXPORT_TEMPLATES_DIR}
 
 #------------------------------
 # All desktop templates


### PR DESCRIPTION
## Summary
* store newline charts the new versioned export dir layout introduced in Godot 3.6
* copy the base windows templates before UWP so the directory exists when BuildKit checksums it